### PR TITLE
Reduce spacing before survey overview toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -141,7 +141,7 @@ Promemoria per la configurazione di Formsubmit
     }
 
     .overview-wrapper {
-      margin-top: clamp(1.8rem, 3.5vh, 2.8rem);
+      margin-top: clamp(0.8rem, 2vh, 1.2rem);
       display: flex;
       flex-direction: column;
       align-items: center;


### PR DESCRIPTION
## Summary
- decrease the top margin on the overview wrapper to bring the + toggle closer to the instruction text on the welcome card

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d3d1ce5188832096961bac38491568