### PR TITLE
Remove plus icons from welcome sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -1400,7 +1400,7 @@ L'obiettivo è capire come il pubblico percepisce la qualità dell'adattamento, 
               </div>
             `
             : '';
-          const iconMarkup = hasPanel ? '<span class="toggle-icon" aria-hidden="true"></span>' : '';
+          const iconMarkup = '';
           return `
             <section class="overview-section" data-open="${openValue}">
               <button class="overview-toggle" type="button" id="${sectionId}" aria-expanded="${expandedValue}"${controlsAttr}>


### PR DESCRIPTION
## Summary
- remove the plus toggle icon from each section in the welcome overview so the first page blocks show no + symbol

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68d3d54e82108320a38e539a946049ae