### PR TITLE
Equalize video and question columns

### DIFF
--- a/index.html
+++ b/index.html
@@ -494,16 +494,15 @@ Promemoria per la configurazione di Formsubmit
     }
 
     .video-step {
-      display: flex;
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
       gap: clamp(1.5rem, 3vw, 3rem);
       align-items: stretch;
       margin-top: 3rem;
-      flex-wrap: wrap;
     }
 
     .video-area {
-      flex: 1 1 480px;
-      min-width: 300px;
+      min-width: 0;
     }
 
     video {
@@ -538,8 +537,7 @@ Promemoria per la configurazione di Formsubmit
     }
 
     .questions {
-      flex: 1 1 360px;
-      min-width: 320px;
+      min-width: 0;
       background: linear-gradient(165deg, rgba(10, 16, 24, 0.92), rgba(7, 12, 20, 0.86));
       border-radius: 22px;
       padding: clamp(1.75rem, 2.5vw, 2.4rem);


### PR DESCRIPTION
## Summary
- use a responsive CSS grid for the video/question step layout so the two panels share the available width
- allow both panels to shrink evenly by removing fixed flex-basis constraints

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68de81d83b6c83208e339e37cc0eb8cd