### PR TITLE
Allow dynamic video counts per content

### DIFF
--- a/index.html
+++ b/index.html
@@ -1448,7 +1448,7 @@ Promemoria per la configurazione di Formsubmit
             </div>
             <h1 id="welcome-title">${escapeHtml(state.config.SURVEY_TITLE)}</h1>
             <p>Benvenuto! <br> Stiamo conducendo un blind test su brevi clip doppiate da professionisti umani o da sistemi di intelligenza artificiale. <br>
-L'obiettivo è capire come il pubblico percepisce la qualità dell'adattamento, la corrispondenza vocale e la naturalezza della recitazione. <br> Il percorso è organizzato in due aree: <strong>Clip estere tradotte in italiano</strong> (Documentario · Liquid Universe, Serie TV Turca · Yargi, Serie TV US · Chicago Fire) e <strong>Da italiano a inglese</strong> (Documentario · Viaggio nella Grande Bellezza, Serie TV · Squadra Antimafia, TV Show · La Casa Fuerte). Ogni contenuto propone le stesse domande per cinque clip o per l'intera selezione disponibile.</p>
+L'obiettivo è capire come il pubblico percepisce la qualità dell'adattamento, la corrispondenza vocale e la naturalezza della recitazione. <br> Il percorso è organizzato in due aree: <strong>Clip estere tradotte in italiano</strong> (Documentario · Liquid Universe, Serie TV Turca · Yargi, Serie TV US · Chicago Fire) e <strong>Da italiano a inglese</strong> (Documentario · Viaggio nella Grande Bellezza, Serie TV · Squadra Antimafia, TV Show · La Casa Fuerte). Ogni contenuto propone le stesse domande per tutte le clip disponibili.</p>
 <p> Clicca sul <strong> + </strong> per esplorare il contenuto della survey. </p>
             ${overviewWrapperMarkup}
             <p> Clicca “Inizia” per cominciare. </p>
@@ -2193,8 +2193,8 @@ L'obiettivo è capire come il pubblico percepisce la qualità dell'adattamento, 
             const contentDescription = isNonEmptyString(content.description) ? content.description.trim() : '';
             const contentBase = isNonEmptyString(content.baseUrl) ? content.baseUrl : sectionBase;
             const contentId = makeSafeId(content.id, `${title}-${contentTitle}`, `${id}-content-${contentIndex + 1}`);
-            if (!Array.isArray(content.videos) || content.videos.length !== 5) {
-              throw new Error(`Il contenuto "${contentTitle}" nella sezione "${title}" deve includere esattamente 5 video.`);
+            if (!Array.isArray(content.videos) || content.videos.length === 0) {
+              throw new Error(`Il contenuto "${contentTitle}" nella sezione "${title}" deve includere almeno un video.`);
             }
             const normalizedVideos = normalizeVideos(content.videos, contentBase).map((url, videoIndex) => ({
               url,


### PR DESCRIPTION
## Summary
- relax content validation to require at least one video instead of exactly five
- update the configuration error message to reflect the new requirement

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e4e8072d548320a768030127b74111